### PR TITLE
v19.2.3

### DIFF
--- a/IntegradorCore/API/ConsultaXML.cs
+++ b/IntegradorCore/API/ConsultaXML.cs
@@ -34,7 +34,7 @@ namespace IntegradorCore.API
         {
             var wsClient = DefineBaseClient(Base);
             var request = new ConsultarLoteEventosRequestBody();
-
+            
             string strResponse = "";
 
             try

--- a/IntegradorCore/DAO/Banco.cs
+++ b/IntegradorCore/DAO/Banco.cs
@@ -141,7 +141,11 @@ namespace IntegradorCore.DAO
                 var sql = "UPDATE ZMDATVIVES_EVENTOS_ESOCIAL SET NROPROTOCOLO = :Nrprot, XMLPROTOCOLO = :Xmlprot, MENSAGEMERRO = :Erro, DATARETORNO = :Dtretorno, HORARETORNO = :Hrretorno, STATUS = :Status  WHERE ID = :Idevento AND IDSEQ = :Idseq";
                 sql = sql.Replace(":Nrprot", string.Concat(quote + prot.nroProt + quote));
                 sql = sql.Replace(":Xmlprot", string.Concat(quote + (prot.xmlProt = prot.xmlProt.Replace("> <", "><")) + quote));
-                sql = sql.Replace(":Erro", string.Concat(quote + prot.erros + quote));
+                if(String.IsNullOrEmpty(prot.erros)){
+                    sql = sql.Replace(":Erro", string.Concat(quote + "null" + quote));
+                }else{
+                    sql = sql.Replace(":Erro", string.Concat(quote + prot.erros.Replace("'", "") + quote));
+                }
                 if (StaticParametersDB.GetDriver() == "oracle")
                 {
                     sql = sql.Replace(":Dtretorno", "trunc(SYSDATE)");
@@ -421,7 +425,14 @@ namespace IntegradorCore.DAO
                     OracleCommand oraCommand = new OracleCommand("UPDATE ZMDATVIVES_EVENTOS_ESOCIAL SET NROPROTOCOLO = :Nrprot, XMLPROTOCOLO = :Xmlprot, MENSAGEMERRO = :Erro, DATARETORNO = :Dtretorno, HORARETORNO = :Hrretorno, STATUS = :Status  WHERE ID = :Idevento AND IDSEQ = :Idseq");
                     oraCommand.Parameters.Add(new OracleParameter(":Nrprot", prot.nroProt));
                     oraCommand.Parameters.Add(new OracleParameter(":Xmlprot", prot.xmlProt));
-                    oraCommand.Parameters.Add(new OracleParameter(":Erro", prot.erros));
+                    if(String.IsNullOrEmpty(prot.erros))
+                    {
+                        oraCommand.Parameters.Add(new OracleParameter(":Erro", DBNull.Value));
+                    }
+                    else
+                    {
+                        oraCommand.Parameters.Add(new OracleParameter(":Erro", prot.erros.Replace("'", "")));
+                    }
                     oraCommand.Parameters.Add(new OracleParameter(":Dtretorno", prot.dtconsulta));
                     oraCommand.Parameters.Add(new OracleParameter(":Hrretorno", prot.hrconsulta));
                     oraCommand.Parameters.Add(new OracleParameter(":Status", prot.status));
@@ -476,7 +487,11 @@ namespace IntegradorCore.DAO
                     SqlCommand sqlCommand = new SqlCommand("UPDATE ZMDATVIVES_EVENTOS_ESOCIAL SET NROPROTOCOLO = @Nrprot, XMLPROTOCOLO = @Xmlprot, MENSAGEMERRO = @Erro, DATARETORNO = @Dtretorno, HORARETORNO = @Hrretorno, STATUS = @Status  WHERE ID = @Idevento AND IDSEQ = @Idseq");
                     sqlCommand.Parameters.Add(new SqlParameter("@Nrprot", prot.nroProt));
                     sqlCommand.Parameters.Add(new SqlParameter("@Xmlprot", prot.xmlProt));
-                    sqlCommand.Parameters.Add(new SqlParameter("@Erro", prot.erros));
+                    if(String.IsNullOrEmpty(prot.erros)){
+                        sqlCommand.Parameters.Add(new SqlParameter("@Erro", DBNull.Value));
+                    }else{
+                        sqlCommand.Parameters.Add(new SqlParameter("@Erro", prot.erros.Replace("'", "")));
+                    }
                     sqlCommand.Parameters.Add(new SqlParameter("@Dtretorno", Convert.ToDateTime(prot.dtconsulta).ToString(format)));
                     sqlCommand.Parameters.Add(new SqlParameter("@Hrretorno", prot.hrconsulta));
                     sqlCommand.Parameters.Add(new SqlParameter("@Status", prot.status));

--- a/IntegradorCore/DAO/Banco.cs
+++ b/IntegradorCore/DAO/Banco.cs
@@ -296,6 +296,17 @@ namespace IntegradorCore.DAO
                                     ExceptionCore e = new ExceptionCore();
                                     e.ExBanco(30, "ID Evento: " + (Convert.ToString(row["ID"]) + "-" + Convert.ToString(row["IDSEQ"])) + " | Erro: " + ex.Message, StaticParametersDB.GetDriver(), ex, "");
                                 }
+                                else
+                                {
+                                    UpdateDB(
+                                        proc.GeraProtocoloAux("1"
+                                        , Convert.ToString(row["ID"])
+                                        , Convert.ToString(row["IDSEQ"])
+                                        , "<erro>Tag tipo de ambiente não presente no XML</erro>"
+                                        , "0"
+                                        , "Tag tipo de ambiente não presente no XML")
+                                        );
+                                }
                             }
                             
                         }

--- a/IntegradorCore/DAO/Banco.cs
+++ b/IntegradorCore/DAO/Banco.cs
@@ -431,6 +431,10 @@ namespace IntegradorCore.DAO
                     }
                     else
                     {
+                        if(prot.erros.Length > 4000)
+                        {
+                            prot.erros = "Consulte o portal ives para detalhes do erro";
+                        }
                         oraCommand.Parameters.Add(new OracleParameter(":Erro", prot.erros.Replace("'", "")));
                     }
                     oraCommand.Parameters.Add(new OracleParameter(":Dtretorno", prot.dtconsulta));
@@ -487,9 +491,16 @@ namespace IntegradorCore.DAO
                     SqlCommand sqlCommand = new SqlCommand("UPDATE ZMDATVIVES_EVENTOS_ESOCIAL SET NROPROTOCOLO = @Nrprot, XMLPROTOCOLO = @Xmlprot, MENSAGEMERRO = @Erro, DATARETORNO = @Dtretorno, HORARETORNO = @Hrretorno, STATUS = @Status  WHERE ID = @Idevento AND IDSEQ = @Idseq");
                     sqlCommand.Parameters.Add(new SqlParameter("@Nrprot", prot.nroProt));
                     sqlCommand.Parameters.Add(new SqlParameter("@Xmlprot", prot.xmlProt));
-                    if(String.IsNullOrEmpty(prot.erros)){
+                    if(String.IsNullOrEmpty(prot.erros))
+                    {
                         sqlCommand.Parameters.Add(new SqlParameter("@Erro", DBNull.Value));
-                    }else{
+                    }
+                    else
+                    {
+                        if (prot.erros.Length > 4000)
+                        {
+                            prot.erros = "Consulte o portal do iVes para obter detalhes do erro";
+                        }
                         sqlCommand.Parameters.Add(new SqlParameter("@Erro", prot.erros.Replace("'", "")));
                     }
                     sqlCommand.Parameters.Add(new SqlParameter("@Dtretorno", Convert.ToDateTime(prot.dtconsulta).ToString(format)));

--- a/IntegradorCore/DAO/Banco.cs
+++ b/IntegradorCore/DAO/Banco.cs
@@ -275,13 +275,29 @@ namespace IntegradorCore.DAO
                         Processos proc = new Processos();
                         foreach (System.Data.DataRow row in dataTable.Rows)
                         {
-                            var Base = proc.DefineBaseEnvioDB(Convert.ToString(row["XMLEVENTO"]));
-                            var prot = new ProtocoloDB { id = string.Concat(Convert.ToString(row["ID"]), "-", Convert.ToString(row["IDSEQ"])),
-                                                         idEvento = Convert.ToString(row["ID"]), idSeq = Convert.ToString(row["IDSEQ"]),
-                                                         xmlEvento = Convert.ToString(row["XMLEVENTO"]),
-                                                         driver = StaticParametersDB.GetDriver(),
-                                                         baseEnv = Convert.ToString(Base) };
-                            ProtocoloDAO.Salvar(prot);
+                            try
+                            {
+                                var Base = proc.DefineBaseEnvioDB(Convert.ToString(row["XMLEVENTO"]), (Convert.ToString(row["ID"]) + "-" + Convert.ToString(row["IDSEQ"])));
+                                var prot = new ProtocoloDB
+                                {
+                                    id = string.Concat(Convert.ToString(row["ID"]), "-", Convert.ToString(row["IDSEQ"])),
+                                    idEvento = Convert.ToString(row["ID"]),
+                                    idSeq = Convert.ToString(row["IDSEQ"]),
+                                    xmlEvento = Convert.ToString(row["XMLEVENTO"]),
+                                    driver = StaticParametersDB.GetDriver(),
+                                    baseEnv = Convert.ToString(Base)
+                                };
+                                ProtocoloDAO.Salvar(prot);
+                            }
+                            catch (Exception ex)
+                            {
+                                if (ex.HResult != -2147467261)
+                                {
+                                    ExceptionCore e = new ExceptionCore();
+                                    e.ExBanco(30, "ID Evento: " + (Convert.ToString(row["ID"]) + "-" + Convert.ToString(row["IDSEQ"])) + " | Erro: " + ex.Message, StaticParametersDB.GetDriver(), ex, "");
+                                }
+                            }
+                            
                         }
                     }
                 }

--- a/IntegradorCore/Services/Jobs.cs
+++ b/IntegradorCore/Services/Jobs.cs
@@ -264,7 +264,7 @@ namespace IntegradorCore.Services
             var sessao = AuxiliarNhibernate.AbrirSessao();
             ProtocoloDB_DAO ProtocoloDAO = new ProtocoloDB_DAO(sessao);
 
-            ConsultaXML apiConXMLTeste = new ConsultaXML(StaticParametros.GetGrupo(), StaticParametros.GetToken());
+            //ConsultaXML apiConXMLTeste = new ConsultaXML(StaticParametros.GetGrupo(), StaticParametros.GetToken());
             var lista = ProtocoloDAO.BuscaConsulta();
             if (lista.Count > 0)
             {

--- a/IntegradorCore/Services/Processos.cs
+++ b/IntegradorCore/Services/Processos.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/IntegradorCore/Services/Processos.cs
+++ b/IntegradorCore/Services/Processos.cs
@@ -1592,5 +1592,23 @@ namespace IntegradorCore.Services
             }
             
         }
+
+        public ProtocoloDB GeraProtocoloAux(string id, string idEvento, string idSeq, string xmlProt, string nrProt, string erros)
+        {
+            var data = RetornaData();
+            return new ProtocoloDB
+            {
+                id = id,
+                idEvento = idEvento,
+                idSeq = idSeq,
+                nroProt = nrProt,
+                xmlProt = xmlProt,
+                consultado = true,
+                dtconsulta = data[0],
+                hrconsulta = data[1],
+                status = "3 - Rejeitado",
+                erros = erros
+            };
+        }
     }
 }

--- a/IntegradorCore/Services/Processos.cs
+++ b/IntegradorCore/Services/Processos.cs
@@ -1362,7 +1362,7 @@ namespace IntegradorCore.Services
             
         }
 
-        public bool DefineBaseEnvioDB(string xml)
+        public bool DefineBaseEnvioDB(string xml, string id)
         {
 
             XmlDocument doc = new XmlDocument();
@@ -1370,20 +1370,32 @@ namespace IntegradorCore.Services
 
             var elemListRetEve = doc.GetElementsByTagName("tpAmb");
 
-            foreach (XmlNode item in elemListRetEve[0].ChildNodes)
+            try
             {
-                if (item.InnerText == "1")
+                foreach (XmlNode item in elemListRetEve[0].ChildNodes)
                 {
-                    return false;
+                    if (item.InnerText == "1")
+                    {
+                        return false;
+                    }
+                    else
+                    {
+                        return true;
+                    }
                 }
-                else
-                {
-                    return true;
-                }
+                return true;
             }
-
-            return true;
-
+            
+            catch (Exception ex)
+            {
+                if (ex.HResult == -2147467261)
+                {
+                    ExceptionCore e = new ExceptionCore();
+                    e.ExBanco(10001, "ID Evento: "+ id +" | Tag tipo de ambiente não está presente no xml", StaticParametersDB.GetDriver(), ex, "");
+                }
+                throw ex;
+            }
+            
         }
 
         public void VerificaParaAtualizar()

--- a/IntegradorCore/Services/Processos.cs
+++ b/IntegradorCore/Services/Processos.cs
@@ -1011,7 +1011,7 @@ namespace IntegradorCore.Services
                     {
                         var dt = Convert.ToDateTime(row.Data);
                         var qtd = DiferencaDataDias(dt, DateTime.Now);
-                        if (qtd > 25)
+                        if (qtd > 8)
                         {
                             if (remover.Find(x => x.Contains(Convert.ToString(row.Data))) == null)
                                 remover.Add(Convert.ToString(row.Data));
@@ -1032,7 +1032,7 @@ namespace IntegradorCore.Services
                     {
                         var dt = Convert.ToDateTime(row.Data);
                         var qtd = DiferencaDataDias(dt, DateTime.Now);
-                        if (qtd > 25)
+                        if (qtd > 8)
                         {
                             if (remover.Find(x => x.Contains(Convert.ToString(row.Data))) == null)
                                 remover.Add(Convert.ToString(row.Data));
@@ -1053,7 +1053,7 @@ namespace IntegradorCore.Services
                     {
                         var dt = Convert.ToDateTime(row.Data);
                         var qtd = DiferencaDataDias(dt, DateTime.Now);
-                        if (qtd > 25)
+                        if (qtd > 8)
                         {
                             if (remover.Find(x => x.Contains(Convert.ToString(row.Data))) == null)
                                 remover.Add(Convert.ToString(row.Data));
@@ -1074,7 +1074,7 @@ namespace IntegradorCore.Services
                     {
                         var dt = Convert.ToDateTime(lt.Data);
                         var qtd = DiferencaDataDias(dt, DateTime.Now);
-                        if (qtd > 25)
+                        if (qtd > 8)
                         {
                             if (remover.Find(x => x.Contains(Convert.ToString(lt.Data))) == null)
                                 remover.Add(Convert.ToString(lt.Data));
@@ -1086,10 +1086,16 @@ namespace IntegradorCore.Services
                         logInterno.DeleteByData(item);
                     }
                 }
-
-                Atualizador.Vaccum();
             }
             catch (Exception ex)
+            {
+                //noOp
+            }
+            try
+            {
+                Atualizador.Vaccum();
+            }
+            catch(Exception ex)
             {
                 //noOp
             }

--- a/IntegradorCore/Services/StaticParametros.cs
+++ b/IntegradorCore/Services/StaticParametros.cs
@@ -21,7 +21,7 @@ namespace IntegradorCore.Services
         private static bool Base = false; //Base de dados definida pelo usuário
         private static bool IntegraBanco = false;
         private static bool LockVariavel = false;
-        private static readonly string Versao = "18.8.4";
+        private static readonly string Versao = "19.2.1";
         #endregion
 
         #region Param

--- a/IntegradorCore/Services/StaticParametros.cs
+++ b/IntegradorCore/Services/StaticParametros.cs
@@ -21,7 +21,7 @@ namespace IntegradorCore.Services
         private static bool Base = false; //Base de dados definida pelo usuário
         private static bool IntegraBanco = false;
         private static bool LockVariavel = false;
-        private static readonly string Versao = "19.2.2";
+        private static readonly string Versao = "19.2.3";
         #endregion
 
         #region Param

--- a/IntegradorCore/Services/StaticParametros.cs
+++ b/IntegradorCore/Services/StaticParametros.cs
@@ -21,7 +21,7 @@ namespace IntegradorCore.Services
         private static bool Base = false; //Base de dados definida pelo usuário
         private static bool IntegraBanco = false;
         private static bool LockVariavel = false;
-        private static readonly string Versao = "19.2.1";
+        private static readonly string Versao = "19.2.2";
         #endregion
 
         #region Param


### PR DESCRIPTION
- Correções na ação de update do banco de dados SQLServer e Oracle;

- Agora é feita a tentativa de salvar os erros originais no banco SQLServer e Oracle, caso retorne erro referente limite excedido de caractere, é alterada a mensagem original orientando para que consulte o erro no iVes;

- "Rejeitando" automaticamente eventos que não tenha a tag tpamb no XML;

- Mudança nos logs para que sejam excluídos após 7 dias;